### PR TITLE
Bump js-md5 and js-sha1 to MYC fork versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+MyCrypto: This is a fork of **uuid-by-string**.
+Due to security concerns, **js-md5** and **js-sha1** are forks.
+
 uuid-by-string
 [![NPM](https://img.shields.io/npm/v/uuid-by-string.svg?style=flat-square&maxAge=3600)](https://www.npmjs.com/package/uuid-by-string)
 [![Downloads](https://img.shields.io/npm/dw/uuid-by-string.svg?style=flat-square&maxAge=3600)](https://www.npmjs.com/package/uuid-by-string)

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     ]
   },
   "dependencies": {
-    "js-md5": "^0.7.3",
-    "js-sha1": "^0.6.0"
+    "js-md5": "MyCryptoHQ/js-md5#b300da8",
+    "js-sha1": "MyCryptoHQ/js-sha1#7474a6"
   },
   "devDependencies": {
     "jest": "^24.8.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1962,15 +1962,13 @@ jest@^24.8.0:
     import-local "^2.0.0"
     jest-cli "^24.8.0"
 
-js-md5@^0.7.3:
+js-md5@MyCryptoHQ/js-md5#b300da8:
   version "0.7.3"
-  resolved "https://registry.yarnpkg.com/js-md5/-/js-md5-0.7.3.tgz#b4f2fbb0b327455f598d6727e38ec272cd09c3f2"
-  integrity sha512-ZC41vPSTLKGwIRjqDh8DfXoCrdQIyBgspJVPXHBGu4nZlAEvG3nf+jO9avM9RmLiGakg7vz974ms99nEV0tmTQ==
+  resolved "https://codeload.github.com/MyCryptoHQ/js-md5/tar.gz/b300da833e5e2c83dae186359b72c69e1711acd2"
 
-js-sha1@^0.6.0:
+js-sha1@MyCryptoHQ/js-sha1#7474a6:
   version "0.6.0"
-  resolved "https://registry.yarnpkg.com/js-sha1/-/js-sha1-0.6.0.tgz#adbee10f0e8e18aa07cdea807cf08e9183dbc7f9"
-  integrity sha512-01gwBFreYydzmU9BmZxpVk6svJJHrVxEN3IOiGl6VO93bVKYETJ0sIth6DASI6mIFdt7NmfX9UiByRzsYHGU9w==
+  resolved "https://codeload.github.com/MyCryptoHQ/js-sha1/tar.gz/7474a6478649ff9a784e565a71c2c97ab18ef634"
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Bump js-md5 and js-sha1 to MYC fork versions for security reasons.
Those forks remove the eval() function which could be a possible security threat.